### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/fingerpi/interactive.py
+++ b/fingerpi/interactive.py
@@ -32,7 +32,7 @@ def runmenu(screen, menu, parent, status_mid = '', status_bottom = ''):
     if parent is None:
         lastoption = "Exit"
     else:
-        lastoption = "Return to %s menu" % parent['title']
+        lastoption = "Return to {0!s} menu".format(parent['title'])
 
     optioncount = len(menu['options']) # how many options in this menu
 
@@ -63,12 +63,12 @@ def runmenu(screen, menu, parent, status_mid = '', status_bottom = ''):
                 textstyle = n
                 if pos==index:
                     textstyle = h
-                screen.addstr(5+index,4, "%d - %s" % (index+1, menu['options'][index]['title']), textstyle)
+                screen.addstr(5+index,4, "{0:d} - {1!s}".format(index+1, menu['options'][index]['title']), textstyle)
             # Now display Exit/Return at bottom of menu
             textstyle = n
             if pos==optioncount:
                 textstyle = h
-            screen.addstr(5+optioncount,4, "%d - %s" % (optioncount+1, lastoption), textstyle)
+            screen.addstr(5+optioncount,4, "{0:d} - {1!s}".format(optioncount+1, lastoption), textstyle)
 
             # Add the status of the connection and of the response
             screen.clrtobot()

--- a/fingerpi/menu_data.py
+++ b/fingerpi/menu_data.py
@@ -290,7 +290,7 @@ class Commands():
                 if response[0]['ACK']:
                     # screen.addstr(3, 2, 'ID in use!')
                     # screen.clrtoeol()
-                    ret[0] = 'Enrollment of ID %d started'%response[0]['Parameter']
+                    ret[0] = 'Enrollment of ID {0:d} started'.format(response[0]['Parameter'])
                     break
                 else:
                     screen.addstr(3, 2, response[0]['Parameter'])
@@ -361,7 +361,7 @@ class Commands():
                 if response[0]['ACK']:
                     # screen.addstr(3, 2, 'ID in use!')
                     # screen.clrtoeol()
-                    ret[0] = 'ID %d deleted'%ID
+                    ret[0] = 'ID {0:d} deleted'.format(ID)
                     break
                 else:
                     screen.addstr(3, 2, response[0]['Parameter'])
@@ -402,7 +402,7 @@ class Commands():
                 if response[0]['ACK']:
                     # screen.addstr(3, 2, 'ID in use!')
                     # screen.clrtoeol()
-                    ret[0] = 'ID %d verified'%ID
+                    ret[0] = 'ID {0:d} verified'.format(ID)
                     break
                 else:
                     screen.addstr(3, 2, response[0]['Parameter'])


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:zafartahirov:fingerpi?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:zafartahirov:fingerpi?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)