### PR TITLE
Wrong key. Changed key 'DeviceID' to 'DeviceId'.

### DIFF
--- a/fingerpi/base.py
+++ b/fingerpi/base.py
@@ -78,7 +78,7 @@ def encode_data_packet(
 def decode_command_packet(packet):
     response = {
         'Header': None,
-        'DeviceID': None,
+        'DeviceId': None,
         'ACK': None,
         'Parameter': None,
         'Checksum': None        


### PR DESCRIPTION
The key 'DeviceID' is refered in fingerpi.py as 'DeviceId' (line 174)