### PR TITLE
Fix NameError & AttributeError in menu_data.py

### DIFF
--- a/gui/menu_data.py
+++ b/gui/menu_data.py
@@ -205,7 +205,7 @@ class Commands():
         if not self.open:
             raise NotOpenError('Please, open the port first!')
         response = self._f.UsbInternalCheck()
-        if reponse[0]['ACK']:
+        if response[0]['ACK']:
             return ['USB Internal Check returned: ' + str(response[0]['Parameter']), None]
         else:
             raise NackError(response[0]['Parameter'])

--- a/gui/menu_data.py
+++ b/gui/menu_data.py
@@ -51,7 +51,7 @@ def _serial_ports():
             s = serial.Serial(port)
             s.close()
             result.append([str(port), port, False]) # Message, Port, Default port?
-        except (OSError, serial.Exception):
+        except (OSError, serial.SerialException):
             print "(!) Cannot open " + str(port)
             pass # We are just checking the ports!
     if not result:


### PR DESCRIPTION
UsbInternalCheck
     if reponse[0]['ACK']:
             NameError: global name 'reponse' is not defined

menu_data.py", line 54, in _serial_ports
except (OSError, serial.Exception):
AttributeError: 'module' object has no attribute 'Exception'